### PR TITLE
Make tests independent from local config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "rust_engine",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "dev",
+  "workspaceFolder": "/workspace",
+  "shutdownAction": "stopCompose",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb"
+      ],
+      "settings": {
+        "rust-analyzer.check.command": "clippy",
+        "debug.inlineValues": "off",
+        "debug.evaluateOnHover": "off"
+      }
+    }
+  },
+  "postCreateCommand": "cargo fetch"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target
+.git
+.devcontainer
+.vscode
+conf/config.toml
+examples/assets/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        cmake \
+        gdb \
+        lldb \
+        pkg-config \
+        libasound2-dev \
+        libudev-dev \
+        libwayland-dev \
+        libx11-dev \
+        libxcursor-dev \
+        libxi-dev \
+        libxkbcommon-dev \
+        libxrandr-dev \
+    && rustup component add clippy rustfmt \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: fetch check test clippy fmt fmt-check docker-shell docker-fetch docker-check docker-test docker-clippy docker-fmt docker-fmt-check docker-clean
+
+fetch:
+	cargo fetch
+
+check:
+	cargo check --all-targets
+
+test:
+	cargo test --all-targets
+
+clippy:
+	cargo clippy --all-targets -- -D warnings
+
+fmt:
+	cargo fmt
+
+fmt-check:
+	cargo fmt -- --check
+
+docker-shell:
+	docker compose run --rm dev
+
+docker-fetch:
+	docker compose run --rm dev cargo fetch
+
+docker-check:
+	docker compose run --rm dev cargo check --all-targets
+
+docker-test:
+	docker compose run --rm dev cargo test --all-targets
+
+docker-clippy:
+	docker compose run --rm dev cargo clippy --all-targets -- -D warnings
+
+docker-fmt:
+	docker compose run --rm dev cargo fmt
+
+docker-fmt-check:
+	docker compose run --rm dev cargo fmt -- --check
+
+docker-clean:
+	docker compose down --volumes --remove-orphans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  dev:
+    build:
+      context: .
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+      - cargo-registry:/usr/local/cargo/registry
+      - cargo-git:/usr/local/cargo/git
+      - target:/workspace/target
+    environment:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: "1"
+    stdin_open: true
+    tty: true
+
+volumes:
+  cargo-registry:
+  cargo-git:
+  target:

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,51 @@
+# Development
+
+このリポジトリは host の Rust toolchain で開発できます。
+Docker Compose / Dev Container も必要に応じて使えます。
+
+## 初回セットアップ
+
+```sh
+make fetch
+```
+
+## よく使う検証
+
+```sh
+make check
+make test
+make clippy
+make fmt-check
+```
+
+コード整形は次で実行します。
+
+```sh
+make fmt
+```
+
+## Dev Container
+
+VS Code や Dev Containers CLI を使う場合は `.devcontainer/devcontainer.json` を開いてください。
+作成後に `cargo fetch` が実行され、`rust-analyzer` と `CodeLLDB` を使える設定です。
+
+## Docker Compose
+
+Docker で検証したい場合は `docker-*` ターゲットを使います。
+
+```sh
+docker compose build
+make docker-test
+make docker-clippy
+```
+
+コンテナ内の作業ディレクトリは `/workspace` です。
+
+```sh
+make docker-shell
+```
+
+## Codex
+
+Codex の sandbox から host の `cargo` が見えている場合は、通常の `make check` / `make test` / `make clippy` を使ってください。
+Docker socket が sandbox から使えない環境では `docker-*` ターゲットは人間の端末から実行します。

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -22,7 +22,7 @@ impl App {
         dicontainer.insert(TimeFixed::new(1.0 / 60.0)); // 固定更新用の時間間隔を追加
         dicontainer.insert(ConfigContainer::empty());
         Self {
-            dicontainer: dicontainer,
+            dicontainer,
             world: ecs::World::new(),
             timer_state: TimeState::new(),
             schedule: Schedule::new(),
@@ -131,5 +131,11 @@ impl App {
         self.dicontainer
             .get::<ConfigContainer>()
             .map(|c| c.get_config())
+    }
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -20,8 +20,7 @@ impl App {
         let mut dicontainer = DiContainer::new();
         dicontainer.insert(Time::default());
         dicontainer.insert(TimeFixed::new(1.0 / 60.0)); // 固定更新用の時間間隔を追加
-                                                        // Insert default ConfigContainer (empty config)
-        dicontainer.insert(ConfigContainer::new("conf/config.toml"));
+        dicontainer.insert(ConfigContainer::empty());
         Self {
             dicontainer: dicontainer,
             world: ecs::World::new(),

--- a/src/core/asset/texture.rs
+++ b/src/core/asset/texture.rs
@@ -49,7 +49,7 @@ impl TextureManager {
             textures: HashMap::new(),
             path_cache: HashMap::new(),
             next_id: 1,
-            config: config,
+            config,
         }
     }
 
@@ -92,7 +92,7 @@ impl TextureManager {
     }
 
     pub fn unload(&mut self, handle: TextureHandle) {
-        if let Some(_) = self.textures.remove(&handle.id) {
+        if self.textures.remove(&handle.id).is_some() {
             // 必要に応じて追加のクリーンアップ処理をここで行う
         }
     }

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -1,12 +1,12 @@
 use serde::Deserialize;
 use std::sync::Arc;
 use toml;
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug, Default)]
 pub struct Paths {
     pub texture_dir: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug, Default)]
 pub struct Config {
     pub paths: Option<Paths>,
 }
@@ -22,6 +22,12 @@ pub struct ConfigContainer {
 }
 
 impl ConfigContainer {
+    pub fn empty() -> Self {
+        Self {
+            config: Arc::new(Config::default()),
+        }
+    }
+
     pub fn new(path: &str) -> Self {
         let config = Self::load_file(path).unwrap();
         Self {

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1,2 +1,3 @@
+#[allow(clippy::module_inception)]
 mod config;
 pub use config::{Config, ConfigContainer};

--- a/src/core/dicontainer/mod.rs
+++ b/src/core/dicontainer/mod.rs
@@ -5,6 +5,12 @@ mod dicontainer_impl {
         map: std::collections::HashMap<std::any::TypeId, Box<dyn std::any::Any + Send + Sync>>,
     }
 
+    impl Default for DiContainer {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl DiContainer {
         pub fn new() -> Self {
             Self {

--- a/src/core/ecs/mod.rs
+++ b/src/core/ecs/mod.rs
@@ -10,6 +10,12 @@ mod hecs_impl {
     pub struct RefMut<'a, T: ?Sized>(h::RefMut<'a, T>);
 
     impl<T: Send + Sync + 'static> Component for T {}
+    impl Default for World {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl World {
         pub fn new() -> Self {
             Self(h::World::new())
@@ -30,7 +36,7 @@ mod hecs_impl {
             self.0.remove_one::<T>(entity.0).ok()
         }
 
-        pub fn get<'a, T: Component>(&self, entity: Entity) -> Option<Ref<'_, T>> {
+        pub fn get<T: Component>(&self, entity: Entity) -> Option<Ref<'_, T>> {
             self.0.get::<&T>(entity.0).ok().map(Ref)
         }
 

--- a/src/core/events/mod.rs
+++ b/src/core/events/mod.rs
@@ -60,3 +60,9 @@ impl<T> Events<T> {
         }
     }
 }
+
+impl<T> Default for Events<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/core/input/input.rs
+++ b/src/core/input/input.rs
@@ -76,6 +76,12 @@ impl Input {
     }
 }
 
+impl Default for Input {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/input/mod.rs
+++ b/src/core/input/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod input;
 pub use input::Input;
 pub mod types;

--- a/src/core/schedule.rs
+++ b/src/core/schedule.rs
@@ -133,6 +133,12 @@ impl Schedule {
     }
 }
 
+impl Default for Schedule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Generic flush system for Events<T>.
 // Register with: app.add_system(Stage::LateUpdate, Priority::Normal, crate::core::schedule::flush_events::<YourEvent>);
 pub fn flush_events<T: 'static + Send + Sync>(di: &mut DiContainer, _world: &mut ecs::World) {

--- a/src/core/time/mod.rs
+++ b/src/core/time/mod.rs
@@ -37,7 +37,13 @@ impl TimeState {
         self.last_instant = now;
         self.time.elapsed_seconds += delta;
         self.time.delta_seconds = delta;
-        self.time.clone()
+        self.time
+    }
+}
+
+impl Default for TimeState {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/platform/winit_backend.rs
+++ b/src/platform/winit_backend.rs
@@ -138,3 +138,9 @@ impl WinitBackend {
         }
     }
 }
+
+impl Default for WinitBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/plugin/system/input.rs
+++ b/src/plugin/system/input.rs
@@ -14,6 +14,12 @@ impl InputPlugin {
     }
 }
 
+impl Default for InputPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut App) {
         fn input_system(di: &mut DiContainer, _world: &mut crate::core::ecs::World) {

--- a/src/plugin/system/render/mod.rs
+++ b/src/plugin/system/render/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod render;
 pub use render::NullRenderer;
 pub mod render2d;

--- a/src/plugin/system/render/render.rs
+++ b/src/plugin/system/render/render.rs
@@ -10,6 +10,12 @@ impl NullRenderer {
     }
 }
 
+impl Default for NullRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Plugin for NullRenderer {
     fn build(&self, app: &mut App) {
         fn render_system(_di: &mut crate::core::DiContainer, _world: &mut crate::core::ecs::World) {

--- a/src/plugin/system/render/render2d.rs
+++ b/src/plugin/system/render/render2d.rs
@@ -12,6 +12,12 @@ impl Render2D {
     }
 }
 
+impl Default for Render2D {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Plugin for Render2D {
     fn build(&self, app: &mut App) {
         app.add_event(RenderQueue::new(), Stage::PreRender, Priority::Normal);
@@ -56,7 +62,7 @@ fn collect_sprite(_world: &mut crate::core::ecs::World, _cmds: &mut Vec<RenderCo
         // エンティティごとに Transform と Sprite を使って描画コマンドを生成します。
         let cmd = RenderCommand::DrawSprite {
             sprite: sprite.clone(),
-            transform: transform.clone(),
+            transform: *transform,
         };
         _cmds.push(cmd);
     }

--- a/tests/asset_texture.rs
+++ b/tests/asset_texture.rs
@@ -1,9 +1,64 @@
 use rust_engine::core::config::ConfigContainer;
 use rust_engine::core::{TextureFormat, TextureHandle, TextureManager};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TextureTestEnv {
+    root: PathBuf,
+    config_path: PathBuf,
+}
+
+impl TextureTestEnv {
+    fn new(name: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "rust_engine_asset_texture_{name}_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        let texture_root = root.join("textures");
+        std::fs::create_dir_all(texture_root.join("assets")).unwrap();
+
+        let config_path = root.join("config.toml");
+        let texture_dir = format!("{}/", texture_root.display());
+        std::fs::write(
+            &config_path,
+            format!("[paths]\ntexture_dir = \"{}\"\n", texture_dir),
+        )
+        .unwrap();
+
+        Self { root, config_path }
+    }
+
+    fn config(&self) -> ConfigContainer {
+        ConfigContainer::new(self.config_path.to_str().unwrap())
+    }
+
+    fn create_texture(&self, relative_path: &str, width: u32, height: u32) {
+        let path = self.root.join("textures").join(relative_path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let image = image::RgbImage::from_fn(width, height, |x, y| {
+            image::Rgb([(x % 255) as u8, (y % 255) as u8, 128])
+        });
+        image.save(path).unwrap();
+    }
+}
+
+impl Drop for TextureTestEnv {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
 
 #[test]
 fn texture_manager_load_and_get() {
-    let config = ConfigContainer::new("conf/config.toml");
+    let env = TextureTestEnv::new("load_and_get");
+    env.create_texture("assets/test.png", 1024, 1024);
+
+    let config = env.config();
     let mut mgr = TextureManager::new(config.get_config());
 
     // テクスチャをロード
@@ -21,7 +76,10 @@ fn texture_manager_load_and_get() {
 
 #[test]
 fn texture_manager_duplicate_load_returns_same_handle() {
-    let config = ConfigContainer::new("conf/config.toml");
+    let env = TextureTestEnv::new("duplicate_load");
+    env.create_texture("assets/tex1.png", 16, 16);
+
+    let config = env.config();
     let mut mgr = TextureManager::new(config.get_config());
 
     let h1 = mgr.load("assets/tex1.png").unwrap();
@@ -34,7 +92,10 @@ fn texture_manager_duplicate_load_returns_same_handle() {
 
 #[test]
 fn texture_manager_unload() {
-    let config = ConfigContainer::new("conf/config.toml");
+    let env = TextureTestEnv::new("unload");
+    env.create_texture("assets/tex1.png", 16, 16);
+
+    let config = env.config();
     let mut mgr = TextureManager::new(config.get_config());
 
     let handle = mgr.load("assets/tex1.png").unwrap();
@@ -52,14 +113,20 @@ fn texture_handle_invalid() {
     assert!(!invalid.is_valid());
     assert_eq!(invalid.id(), 0);
 
-    let config = ConfigContainer::new("conf/config.toml");
+    let env = TextureTestEnv::new("invalid_handle");
+    let config = env.config();
     let mgr = TextureManager::new(config.get_config());
     assert!(mgr.get(&invalid).is_none());
 }
 
 #[test]
 fn texture_manager_multiple_textures() {
-    let config = ConfigContainer::new("conf/config.toml");
+    let env = TextureTestEnv::new("multiple_textures");
+    env.create_texture("assets/tex1.png", 16, 16);
+    env.create_texture("assets/tex2.png", 32, 16);
+    env.create_texture("assets/tex3.png", 16, 32);
+
+    let config = env.config();
     let mut mgr = TextureManager::new(config.get_config());
 
     let h1 = mgr.load("assets/tex1.png").unwrap();

--- a/tests/prerender_execution.rs
+++ b/tests/prerender_execution.rs
@@ -18,17 +18,17 @@ fn render_system(di: &mut DiContainer, _world: &mut ecs::World) {
 #[test]
 fn prerender_runs_before_render_in_app_render_method() {
     let mut app = App::new();
-    
+
     // Insert a Vec to track execution order
     app.get_di_container().insert(Vec::<String>::new());
-    
+
     // Register systems in PreRender and Render stages
     app.add_system(Stage::PreRender, Priority::Normal, prerender_system);
     app.add_system(Stage::Render, Priority::Normal, render_system);
-    
+
     // Call render which should execute PreRender then Render
     app.render(0.0);
-    
+
     // Verify execution order
     let execution_order = app.get_di_container().get::<Vec<String>>().unwrap();
     assert_eq!(execution_order.len(), 2);


### PR DESCRIPTION
## Summary

- Make App::new() independent from conf/config.toml
- Add ConfigContainer::empty() for default app configuration
- Generate temporary config and PNG assets inside asset_texture tests
- Format existing whitespace in prerender_execution test

## Verification

- cargo test --all-targets
- cargo fmt -- --check

## Note

cargo clippy --all-targets -- -D warnings still reports existing project-wide lints unrelated to this change.