### PR TITLE
TextureManager に TextureConfig を値で渡す

### DIFF
--- a/examples/texture_test.rs
+++ b/examples/texture_test.rs
@@ -21,7 +21,7 @@ fn main() {
     {
         let config = {
             let config = app.get_di_container().get::<ConfigContainer>().unwrap();
-            config.get_config()
+            config.get_config().texture_config()
         };
         app.get_di_container().insert(TextureManager::new(config));
     }

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -2,7 +2,6 @@ use crate::core::ecs;
 use crate::core::plugin::Plugin;
 use crate::core::schedule::{Schedule, Stage};
 use crate::core::{DiContainer, Time, TimeFixed, TimeState};
-use std::sync::Arc;
 
 use crate::core::config::{Config, ConfigContainer};
 
@@ -127,7 +126,7 @@ impl App {
     }
 
     /// Get a reference to the loaded Config.
-    pub fn get_config(&self) -> Option<Arc<Config>> {
+    pub fn get_config(&self) -> Option<Config> {
         self.dicontainer
             .get::<ConfigContainer>()
             .map(|c| c.get_config())

--- a/src/core/asset/texture.rs
+++ b/src/core/asset/texture.rs
@@ -1,7 +1,6 @@
-use crate::core::config::Config;
+use crate::core::config::TextureConfig;
 use image::GenericImageView;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 type TextureId = u32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -40,11 +39,11 @@ pub struct TextureManager {
     textures: HashMap<TextureId, TextureData>,
     path_cache: HashMap<String, TextureHandle>,
     next_id: TextureId,
-    config: Arc<Config>,
+    config: TextureConfig,
 }
 
 impl TextureManager {
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: TextureConfig) -> Self {
         Self {
             textures: HashMap::new(),
             path_cache: HashMap::new(),
@@ -59,7 +58,12 @@ impl TextureManager {
         }
         let id = self.next_id;
         self.next_id += 1;
-        let full_path = self.config.get_texture_dir().unwrap() + path;
+        let texture_dir = self
+            .config
+            .texture_dir
+            .as_deref()
+            .ok_or_else(|| "texture_dir is not configured".to_string())?;
+        let full_path = texture_dir.to_string() + path;
         let data = self._load_impl(&full_path)?;
         self.textures.insert(id, data);
         let handle = TextureHandle { id };

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -1,9 +1,13 @@
 use serde::Deserialize;
 use std::path::Path;
-use std::sync::Arc;
 use toml;
 #[derive(Deserialize, Clone, Debug, Default)]
 pub struct Paths {
+    pub texture_dir: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TextureConfig {
     pub texture_dir: Option<String>,
 }
 
@@ -13,13 +17,18 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn get_texture_dir(&self) -> Option<String> {
-        self.paths.as_ref().unwrap().texture_dir.clone()
+    pub fn texture_config(&self) -> TextureConfig {
+        TextureConfig {
+            texture_dir: self
+                .paths
+                .as_ref()
+                .and_then(|paths| paths.texture_dir.clone()),
+        }
     }
 }
 
 pub struct ConfigContainer {
-    config: Arc<Config>,
+    config: Config,
 }
 
 impl ConfigContainer {
@@ -28,9 +37,7 @@ impl ConfigContainer {
     }
 
     pub fn from_config(config: Config) -> Self {
-        Self {
-            config: Arc::new(config),
-        }
+        Self { config }
     }
 
     pub fn load_from_file(path: impl AsRef<Path>) -> Result<Self, String> {
@@ -49,7 +56,7 @@ impl ConfigContainer {
         }
     }
 
-    pub fn get_config(&self) -> Arc<Config> {
+    pub fn get_config(&self) -> Config {
         self.config.clone()
     }
 }

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1,3 +1,3 @@
 #[allow(clippy::module_inception)]
 mod config;
-pub use config::{Config, ConfigContainer};
+pub use config::{Config, ConfigContainer, TextureConfig};

--- a/tests/asset_texture.rs
+++ b/tests/asset_texture.rs
@@ -59,7 +59,7 @@ fn texture_manager_load_and_get() {
     env.create_texture("assets/test.png", 1024, 1024);
 
     let config = env.config();
-    let mut mgr = TextureManager::new(config.get_config());
+    let mut mgr = TextureManager::new(config.get_config().texture_config());
 
     // テクスチャをロード
     let handle = mgr.load("assets/test.png").unwrap();
@@ -80,7 +80,7 @@ fn texture_manager_duplicate_load_returns_same_handle() {
     env.create_texture("assets/tex1.png", 16, 16);
 
     let config = env.config();
-    let mut mgr = TextureManager::new(config.get_config());
+    let mut mgr = TextureManager::new(config.get_config().texture_config());
 
     let h1 = mgr.load("assets/tex1.png").unwrap();
     let h2 = mgr.load("assets/tex1.png").unwrap();
@@ -96,7 +96,7 @@ fn texture_manager_unload() {
     env.create_texture("assets/tex1.png", 16, 16);
 
     let config = env.config();
-    let mut mgr = TextureManager::new(config.get_config());
+    let mut mgr = TextureManager::new(config.get_config().texture_config());
 
     let handle = mgr.load("assets/tex1.png").unwrap();
     assert_eq!(mgr.loaded_count(), 1);
@@ -115,7 +115,7 @@ fn texture_handle_invalid() {
 
     let env = TextureTestEnv::new("invalid_handle");
     let config = env.config();
-    let mgr = TextureManager::new(config.get_config());
+    let mgr = TextureManager::new(config.get_config().texture_config());
     assert!(mgr.get(&invalid).is_none());
 }
 
@@ -127,7 +127,7 @@ fn texture_manager_multiple_textures() {
     env.create_texture("assets/tex3.png", 16, 32);
 
     let config = env.config();
-    let mut mgr = TextureManager::new(config.get_config());
+    let mut mgr = TextureManager::new(config.get_config().texture_config());
 
     let h1 = mgr.load("assets/tex1.png").unwrap();
     let h2 = mgr.load("assets/tex2.png").unwrap();


### PR DESCRIPTION
## 概要

- `TextureConfig` を追加しました。
- `TextureManager` が `Arc<Config>` ではなく、texture 用設定を値で持つようにしました。
- `ConfigContainer` も内部で `Arc<Config>` を持たず、`Config` を値として保持する形にしました。
- 呼び出し側は `config.get_config().texture_config()` で必要な設定だけ渡すようにしました。

## 設計メモ

- `TextureManager` がアプリ全体の `Config` に依存すると、どの設定を使うのか見えにくくなります。
- texture manager が必要な設定だけを `TextureConfig` として渡すことで、依存範囲を小さくしました。
- 設定の実行中反映は、共有参照で暗黙に行うのではなく、必要になった時点で `reload_config` などの明示 API として設計する方針です。
- そのため、現時点では `Arc<Config>` を使わず、起動時設定を値で渡す形にしています。

## 確認したこと

- [x] `make check`
- [x] `make test`
- [x] `make clippy`
- [x] `make fmt-check`

## レビューしてほしい点

- `TextureManager` に `TextureConfig` を値で渡す粒度が適切か
- 設定の実行中反映を今回は扱わず、将来の明示 API に分ける方針でよいか
