### PR TITLE
Config と Texture のエラー型を追加

### DIFF
--- a/src/core/asset/mod.rs
+++ b/src/core/asset/mod.rs
@@ -1,2 +1,2 @@
 mod texture;
-pub use texture::{TextureData, TextureFormat, TextureHandle, TextureManager};
+pub use texture::{TextureData, TextureError, TextureFormat, TextureHandle, TextureManager};

--- a/src/core/asset/texture.rs
+++ b/src/core/asset/texture.rs
@@ -1,6 +1,19 @@
 use crate::core::config::TextureConfig;
 use image::GenericImageView;
 use std::collections::HashMap;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TextureError {
+    #[error("texture_dir is not configured")]
+    MissingTextureDir,
+    #[error("failed to load texture: {path}")]
+    LoadImage {
+        path: PathBuf,
+        source: image::ImageError,
+    },
+}
 
 type TextureId = u32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -52,7 +65,7 @@ impl TextureManager {
         }
     }
 
-    pub fn load(&mut self, path: &str) -> Result<TextureHandle, String> {
+    pub fn load(&mut self, path: &str) -> Result<TextureHandle, TextureError> {
         if let Some(handle) = self.path_cache.get(path) {
             return Ok(*handle);
         }
@@ -62,7 +75,7 @@ impl TextureManager {
             .config
             .texture_dir
             .as_deref()
-            .ok_or_else(|| "texture_dir is not configured".to_string())?;
+            .ok_or(TextureError::MissingTextureDir)?;
         let full_path = texture_dir.to_string() + path;
         let data = self._load_impl(&full_path)?;
         self.textures.insert(id, data);
@@ -71,13 +84,16 @@ impl TextureManager {
         Ok(handle)
     }
 
-    fn _load_impl(&mut self, _path: &str) -> Result<TextureData, String> {
+    fn _load_impl(&mut self, path: &str) -> Result<TextureData, TextureError> {
         // ここで実際のファイル読み込みとデコードを行う
-        let img = match image::open(_path) {
+        let img = match image::open(path) {
             Ok(img) => img,
-            Err(e) => {
-                log::error!("Failed to load image: {}", e);
-                return Err(e.to_string());
+            Err(source) => {
+                log::error!("Failed to load image: {}", source);
+                return Err(TextureError::LoadImage {
+                    path: PathBuf::from(path),
+                    source,
+                });
             }
         };
         let (width, height) = img.dimensions();

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -1,6 +1,22 @@
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
 use toml;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("failed to read config file: {path}")]
+    ReadFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse config file: {path}")]
+    ParseToml {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+}
+
 #[derive(Deserialize, Clone, Debug, Default)]
 pub struct Paths {
     pub texture_dir: Option<String>,
@@ -40,20 +56,27 @@ impl ConfigContainer {
         Self { config }
     }
 
-    pub fn load_from_file(path: impl AsRef<Path>) -> Result<Self, String> {
+    pub fn load_from_file(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
         Self::load_file(path).map(Self::from_config)
     }
 
-    fn load_file(path: impl AsRef<Path>) -> Result<Config, String> {
-        let mut file = std::fs::File::open(path).map_err(|e| e.to_string())?;
+    fn load_file(path: impl AsRef<Path>) -> Result<Config, ConfigError> {
+        let path = path.as_ref();
+        let mut file = std::fs::File::open(path).map_err(|source| ConfigError::ReadFile {
+            path: path.to_path_buf(),
+            source,
+        })?;
         let mut contents = String::new();
-        std::io::Read::read_to_string(&mut file, &mut contents).map_err(|e| e.to_string())?;
-        let config: Result<Config, toml::de::Error> = toml::from_str(&contents);
-
-        match config {
-            Ok(config) => Ok(config),
-            Err(e) => Err(e.to_string()),
-        }
+        std::io::Read::read_to_string(&mut file, &mut contents).map_err(|source| {
+            ConfigError::ReadFile {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+        toml::from_str(&contents).map_err(|source| ConfigError::ParseToml {
+            path: path.to_path_buf(),
+            source,
+        })
     }
 
     pub fn get_config(&self) -> Config {

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -1,3 +1,3 @@
 #[allow(clippy::module_inception)]
 mod config;
-pub use config::{Config, ConfigContainer, TextureConfig};
+pub use config::{Config, ConfigContainer, ConfigError, TextureConfig};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,6 @@ pub use ecs::{Component, Entity, World};
 pub mod time;
 pub use time::{Time, TimeFixed, TimeState};
 pub mod asset;
-pub use asset::{TextureData, TextureFormat, TextureHandle, TextureManager};
+pub use asset::{TextureData, TextureError, TextureFormat, TextureHandle, TextureManager};
 pub mod config;
 pub use config::ConfigContainer;

--- a/tests/asset_texture.rs
+++ b/tests/asset_texture.rs
@@ -1,5 +1,5 @@
 use rust_engine::core::config::ConfigContainer;
-use rust_engine::core::{TextureFormat, TextureHandle, TextureManager};
+use rust_engine::core::{TextureError, TextureFormat, TextureHandle, TextureManager};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -142,4 +142,23 @@ fn texture_manager_multiple_textures() {
     assert!(mgr.get(&h1).is_some());
     assert!(mgr.get(&h2).is_some());
     assert!(mgr.get(&h3).is_some());
+}
+
+#[test]
+fn config_load_missing_file_returns_error() {
+    let missing_path = std::env::temp_dir().join("rust_engine_missing_config_for_test.toml");
+
+    let err = match ConfigContainer::load_from_file(&missing_path) {
+        Ok(_) => panic!("missing config file should fail"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("failed to read config file"));
+}
+
+#[test]
+fn texture_manager_missing_texture_dir_returns_error() {
+    let mut mgr = TextureManager::new(Default::default());
+
+    let err = mgr.load("assets/test.png").unwrap_err();
+    assert!(matches!(err, TextureError::MissingTextureDir));
 }


### PR DESCRIPTION
## 概要

- `ConfigError` を追加し、設定ファイル読み込みと TOML parse の失敗を型で表すようにしました。
- `TextureError` を追加し、`texture_dir` 未設定と画像読み込み失敗を型で表すようにしました。
- `ConfigContainer::load_from_file` と `TextureManager::load` の戻り値を `String` エラーから専用エラー型に変更しました。
- エラーケースのテストを追加しました。

## 設計メモ

- `String` エラーだと呼び出し側が原因を判別しづらいため、`thiserror` を使った enum にしました。
- `ConfigError` は `ReadFile` と `ParseToml` に分けています。
- `TextureError` は `MissingTextureDir` と `LoadImage` に分けています。
- まだ path の結合や texture path の正規化は扱っていません。次の改善として分けるのが良さそうです。

## 確認したこと

- [x] `make check`
- [x] `make test`
- [x] `make clippy`
- [x] `make fmt-check`

## レビューしてほしい点

- `ConfigError` / `TextureError` の粒度が今の段階に合っているか
- エラー型を `core` から re-export する範囲が適切か
