### PR TITLE
Texture のパス結合に Path::join を使う

### DIFF
--- a/src/core/asset/texture.rs
+++ b/src/core/asset/texture.rs
@@ -1,7 +1,7 @@
 use crate::core::config::TextureConfig;
 use image::GenericImageView;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -76,7 +76,7 @@ impl TextureManager {
             .texture_dir
             .as_deref()
             .ok_or(TextureError::MissingTextureDir)?;
-        let full_path = texture_dir.to_string() + path;
+        let full_path = Path::new(texture_dir).join(path);
         let data = self._load_impl(&full_path)?;
         self.textures.insert(id, data);
         let handle = TextureHandle { id };
@@ -84,14 +84,14 @@ impl TextureManager {
         Ok(handle)
     }
 
-    fn _load_impl(&mut self, path: &str) -> Result<TextureData, TextureError> {
+    fn _load_impl(&mut self, path: &Path) -> Result<TextureData, TextureError> {
         // ここで実際のファイル読み込みとデコードを行う
         let img = match image::open(path) {
             Ok(img) => img,
             Err(source) => {
                 log::error!("Failed to load image: {}", source);
                 return Err(TextureError::LoadImage {
-                    path: PathBuf::from(path),
+                    path: path.to_path_buf(),
                     source,
                 });
             }

--- a/tests/asset_texture.rs
+++ b/tests/asset_texture.rs
@@ -10,6 +10,10 @@ struct TextureTestEnv {
 
 impl TextureTestEnv {
     fn new(name: &str) -> Self {
+        Self::new_with_trailing_separator(name, true)
+    }
+
+    fn new_with_trailing_separator(name: &str, trailing_separator: bool) -> Self {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -23,7 +27,11 @@ impl TextureTestEnv {
         std::fs::create_dir_all(texture_root.join("assets")).unwrap();
 
         let config_path = root.join("config.toml");
-        let texture_dir = format!("{}/", texture_root.display());
+        let texture_dir = if trailing_separator {
+            format!("{}/", texture_root.display())
+        } else {
+            texture_root.display().to_string()
+        };
         std::fs::write(
             &config_path,
             format!("[paths]\ntexture_dir = \"{}\"\n", texture_dir),
@@ -88,6 +96,18 @@ fn texture_manager_duplicate_load_returns_same_handle() {
     // 同じパスをロードしたら同じハンドルが返る（キャッシュ）
     assert_eq!(h1, h2);
     assert_eq!(mgr.loaded_count(), 1);
+}
+
+#[test]
+fn texture_manager_loads_when_texture_dir_has_no_trailing_separator() {
+    let env = TextureTestEnv::new_with_trailing_separator("no_trailing_separator", false);
+    env.create_texture("assets/tex1.png", 16, 16);
+
+    let config = env.config();
+    let mut mgr = TextureManager::new(config.get_config().texture_config());
+
+    let handle = mgr.load("assets/tex1.png").unwrap();
+    assert!(handle.is_valid());
 }
 
 #[test]


### PR DESCRIPTION
## 概要

- `TextureManager` の texture path 生成を文字列結合から `Path::join` に変更しました。
- `texture_dir` の末尾に `/` がなくても texture をロードできるテストを追加しました。
- `TextureError::LoadImage` に渡す path も `Path` から `PathBuf` に変換する形にしました。

## 設計メモ

- 文字列結合だと `texture_dir = "examples"` と `path = "assets/tex.png"` が `examplesassets/tex.png` になり得ます。
- `Path::join` を使うことで、platform の path ルールに沿って結合できます。
- 今回は相対 asset path 前提です。絶対 path の扱いや path traversal 対策は別の設計として扱うのがよさそうです。

## 確認したこと

- [x] `make check`
- [x] `make test`
- [x] `make clippy`
- [x] `make fmt-check`

## レビューしてほしい点

- `TextureConfig::texture_dir` は現時点では `String` のままでよいか
- 絶対 path や `..` を含む path の扱いを次のタスクに分けてよいか
