### PR TITLE
keycode のない keyboard input を無視する

### DIFF
--- a/src/platform/winit_backend.rs
+++ b/src/platform/winit_backend.rs
@@ -85,14 +85,16 @@ impl WinitBackend {
                 winit::event::Event::WindowEvent { event, .. } => match event {
                     winit::event::WindowEvent::KeyboardInput { input, .. } => {
                         // キーボード入力処理
-                        if let Some(ev_queue) = app
-                            .get_di_container()
-                            .get_mut::<Events<KeyboardInputEvent>>()
-                        {
-                            ev_queue.send(KeyboardInputEvent {
-                                key: EngineKey::from(input.virtual_keycode.unwrap()),
-                                state: input.state.into(),
-                            });
+                        if let Some(keycode) = input.virtual_keycode {
+                            if let Some(ev_queue) = app
+                                .get_di_container()
+                                .get_mut::<Events<KeyboardInputEvent>>()
+                            {
+                                ev_queue.send(KeyboardInputEvent {
+                                    key: EngineKey::from(keycode),
+                                    state: input.state.into(),
+                                });
+                            }
                         }
                     }
                     winit::event::WindowEvent::MouseInput { button, state, .. } => {


### PR DESCRIPTION
## 概要

- `WinitBackend` で `virtual_keycode` がない keyboard input を無視するようにしました。
- `input.virtual_keycode.unwrap()` による panic を避けます。

## 設計メモ

- `virtual_keycode` は `Option` なので、IME や未知キーなどでは `None` になり得ます。
- エンジン側の `EngineKey` に変換できる keycode がない場合は、input event queue へ流さず無視します。
- `WindowBuilder::build(...).unwrap()` は `WinitBackend::new() -> Result<_, _>` の API 設計に関わるため、今回は別タスクに分けています。

## 確認したこと

- [x] `make check`
- [x] `make test`
- [x] `make clippy`
- [x] `make fmt-check`

## レビューしてほしい点

- `virtual_keycode == None` の keyboard input を無視する方針でよいか
- `WinitBackend::new` のエラー化を別 PR に分ける方針でよいか
