### PR TITLE
WinitBackend の生成失敗を Result で返す

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,12 +3,14 @@ use rust_engine::platform::PollResult;
 use rust_engine::platform::WinitBackend;
 use rust_engine::InputPlugin;
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut app = core::app::App::new();
     app.startup();
     app.set_fixed_dt(1.0 / 60.0);
     app.add_plugin(&InputPlugin::new());
 
-    let mut winit_backend = WinitBackend::new();
+    let mut winit_backend = WinitBackend::try_new()?;
     while winit_backend.poll_once(&mut app) != PollResult::Exit {}
+
+    Ok(())
 }

--- a/examples/texture_test.rs
+++ b/examples/texture_test.rs
@@ -5,7 +5,7 @@ use rust_engine::platform::PollResult;
 use rust_engine::platform::WinitBackend;
 use rust_engine::{InputPlugin, Sprite, Transform2D};
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut app = core::app::App::new();
     app.startup();
     app.set_fixed_dt(1.0 / 60.0);
@@ -29,8 +29,10 @@ fn main() {
     // テクスチャをロードしてスプライトエンティティを作成
     setup_sprites(&mut app);
 
-    let mut winit_backend = WinitBackend::new();
+    let mut winit_backend = WinitBackend::try_new()?;
     while winit_backend.poll_once(&mut app) != PollResult::Exit {}
+
+    Ok(())
 }
 
 fn setup_sprites(app: &mut core::app::App) {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,2 +1,2 @@
 mod winit_backend;
-pub use winit_backend::{PollResult, WinitBackend};
+pub use winit_backend::{PollResult, WinitBackend, WinitError};

--- a/src/platform/winit_backend.rs
+++ b/src/platform/winit_backend.rs
@@ -7,6 +7,12 @@ use winit::event_loop::{ControlFlow, EventLoop};
 use winit::platform::run_return::EventLoopExtRunReturn;
 use winit::window::WindowBuilder;
 
+#[derive(Debug, thiserror::Error)]
+pub enum WinitError {
+    #[error("failed to create window")]
+    WindowCreation(#[from] winit::error::OsError),
+}
+
 pub struct WinitBackend {
     event_loop: EventLoop<()>,
     window: winit::window::Window,
@@ -20,19 +26,18 @@ pub enum PollResult {
     Continue,
 }
 impl WinitBackend {
-    pub fn new() -> Self {
+    pub fn try_new() -> Result<Self, WinitError> {
         let event_loop = EventLoop::new();
         let window = WindowBuilder::new()
             .with_title("Rust Engine")
-            .build(&event_loop)
-            .unwrap();
+            .build(&event_loop)?;
 
-        WinitBackend {
+        Ok(WinitBackend {
             event_loop,
             window,
             accumulator: Duration::ZERO,
             last_instant: Instant::now(),
-        }
+        })
     }
 
     pub fn poll_once(&mut self, app: &mut App) -> PollResult {
@@ -138,11 +143,5 @@ impl WinitBackend {
         } else {
             PollResult::Continue
         }
-    }
-}
-
-impl Default for WinitBackend {
-    fn default() -> Self {
-        Self::new()
     }
 }


### PR DESCRIPTION
## 概要

- WinitBackend の生成 API を new から try_new に変更しました。
- ウィンドウ生成失敗時に panic せず WinitError を返すようにしました。
- examples 側は main から Result を返して try_new のエラーを伝播するようにしました。

## 設計メモ

- ウィンドウ生成は OS や表示環境に依存して失敗しうるため、unwrap ではなく Result で呼び出し側へ返します。
- 失敗しうる生成処理であることを名前から分かるように new ではなく try_new にしました。
- fallible な生成処理と Default は相性が悪いため、Default 実装は削除しました。

## 確認したこと

- [x] make check
- [x] make test
- [x] make clippy
- [x] make fmt-check

## レビューしてほしい点

- try_new という API 名でよいか
- Default 実装を削除する判断でよいか